### PR TITLE
Add option for SSL version

### DIFF
--- a/lib/paysimple.rb
+++ b/lib/paysimple.rb
@@ -9,6 +9,7 @@ require 'json'
 require 'paysimple/version'
 require 'paysimple/endpoint'
 require 'paysimple/util'
+require 'paysimple/config'
 
 # Enumerations
 require 'paysimple/enumerations/issuer'
@@ -36,6 +37,7 @@ require 'paysimple/errors/authentication_error'
 module Paysimple
 
   @api_endpoint = Endpoint::PRODUCTION
+  @ssl_version = Config::DEFAULT_SSL_VERSION
 
   class << self
     attr_accessor :api_key, :api_user, :api_endpoint, :ssl_version

--- a/lib/paysimple.rb
+++ b/lib/paysimple.rb
@@ -38,7 +38,7 @@ module Paysimple
   @api_endpoint = Endpoint::PRODUCTION
 
   class << self
-    attr_accessor :api_key, :api_user, :api_endpoint
+    attr_accessor :api_key, :api_user, :api_endpoint, :ssl_version
   end
 
   def self.request(method, url, params={})
@@ -58,7 +58,7 @@ module Paysimple
     end
 
     request_opts = { headers: request_headers, method: method, open_timeout: 30,
-                     payload: payload, url: url, timeout: 80 }
+                     payload: payload, url: url, timeout: 80, ssl_version: ssl_version }
 
     begin
       response = execute_request(request_opts)
@@ -129,16 +129,16 @@ module Paysimple
       raise general_api_error(rcode, rbody)
     end
 
-    error_code = error_obj[:meta][:errors][:error_code]
-
     case rcode
       when 400, 404
         errors = error_obj[:meta][:errors][:error_messages].collect { |e| e[:message]}
         raise InvalidRequestError.new(errors, rcode, rbody, error_obj)
       when 401
-        raise  AuthenticationError.new(error_code, rcode, rbody, error_obj)
+        error = "Error getting an API token. Check your authentication credentials and resubmit."
+        raise AuthenticationError.new(error, rcode, rbody, error_obj)
       else
-        raise APIError.new(error_code, rcode, rbody, error_obj)
+        error = "There was an error processing the request."
+        raise APIError.new(error, rcode, rbody, error_obj)
     end
   end
 

--- a/lib/paysimple/config.rb
+++ b/lib/paysimple/config.rb
@@ -1,0 +1,5 @@
+module Paysimple
+  class Config
+    DEFAULT_SSL_VERSION = 'TLSv1_2'
+  end
+end

--- a/lib/paysimple/version.rb
+++ b/lib/paysimple/version.rb
@@ -1,3 +1,3 @@
 module Paysimple
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/spec/paysimple_spec.rb
+++ b/spec/paysimple_spec.rb
@@ -6,6 +6,7 @@ describe Paysimple do
     Paysimple.api_endpoint = Paysimple::Endpoint::SANDBOX
     Paysimple.api_user = ENV['API_USER']
     Paysimple.api_key = ENV['API_KEY']
+    Paysimple.ssl_version = "TLSv1_2"
   end
 
   it 'should create customer' do
@@ -43,7 +44,6 @@ describe Paysimple do
 
   it 'should return payments' do
     payments = Paysimple::Payment.find({ page: 1, page_size: 2, lite: false })
-    puts payments.inspect
     expect(payments).to be_instance_of(Array)
     expect(payments.size).to be <= 2
   end

--- a/spec/paysimple_spec.rb
+++ b/spec/paysimple_spec.rb
@@ -6,7 +6,6 @@ describe Paysimple do
     Paysimple.api_endpoint = Paysimple::Endpoint::SANDBOX
     Paysimple.api_user = ENV['API_USER']
     Paysimple.api_key = ENV['API_KEY']
-    Paysimple.ssl_version = "TLSv1_2"
   end
 
   it 'should create customer' do


### PR DESCRIPTION
PaySimple only accepts SSL connections with version TLSv1.2. Since this is an option that can be passed to RestClient and the PaySimple configuration is bound to change in future, I've added this as the option `ssl_version` that is set just like the API key and API user configurations. Yes, it doesn't look like a setting for the Paysimple module, but it at the same time kind of is since it's a restriction from their end.