### PR TITLE
Updated gemspec for rest-client for compatibility

### DIFF
--- a/paysimple.gemspec
+++ b/paysimple.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
 
-  spec.add_dependency('rest-client', '~> 1.4')
+  spec.add_dependency('rest-client', '~> 2')
   spec.add_dependency('json', '~> 1.8.1')
 end


### PR DESCRIPTION
The current version has an out-of-date dependency with the json gem that conflicts with more modern gems, making this gem more difficult to integrate into projects. This PR updates that dependency. This has not been rigorously tested but since this gem only calls to_json and JSON.parse this change should be safe.